### PR TITLE
Keep naked return fixes on a single line

### DIFF
--- a/nakedret.go
+++ b/nakedret.go
@@ -237,7 +237,13 @@ func nakedReturnFix(s *ast.ReturnStmt, funcType *ast.FuncType) *ast.ReturnStmt {
 	for _, result := range funcType.Results.List {
 		for _, ident := range result.Names {
 			if ident != nil {
-				nameExprs = append(nameExprs, ident)
+				idCopy := *ident
+				if len(nameExprs) > 0 {
+					// this keeps the identifiers in the return statement on the same line,
+					// even if the named returns are split across multiple lines in the function declaration
+					idCopy.NamePos = nameExprs[0].Pos()
+				}
+				nameExprs = append(nameExprs, &idCopy)
 			}
 		}
 	}

--- a/nakedret_test.go
+++ b/nakedret_test.go
@@ -53,6 +53,7 @@ var testcases = []struct {
 		"testdata/src/x/nested.go:101: naked return in func `SingleLine` with 1 lines of code",
 		"testdata/src/x/nested.go:103: naked return in func `<func():103>` with 1 lines of code",
 		"testdata/src/x/nested.go:106: naked return in func `SingleLineNested.<func():106>` with 1 lines of code",
+		"testdata/src/x/nested.go:113: naked return in func `NamedReturnsOnMultipleLines` with 5 lines of code",
 		""}, "\n"),
 		testParams{
 			filename:  "testdata/src/x/nested.go",

--- a/testdata/src/x/nested.go
+++ b/testdata/src/x/nested.go
@@ -105,3 +105,10 @@ var SingleLit = func() (err error) { return } // want "naked return in func `<fu
 func SingleLineNested() (err error) {
 	return func() (err error) { return }() // want "naked return in func `SingleLineNested.<func..:106>` with 1 lines of code"
 }
+
+func NamedReturnsOnMultipleLines() (a, b int,
+	c int,
+	d, e string, f string,
+	err error) {
+	return // want "naked return in func `NamedReturnsOnMultipleLines` with 5 lines of code"
+}

--- a/testdata/src/x/nested.go.golden
+++ b/testdata/src/x/nested.go.golden
@@ -105,3 +105,13 @@ var SingleLit = func() (err error) { return err } // want "naked return in func 
 func SingleLineNested() (err error) {
 	return func() (err error) { return err }() // want "naked return in func `SingleLineNested.<func..:106>` with 1 lines of code"
 }
+
+func NamedReturnsOnMultipleLines() (a, b int,
+	c int,
+	d, e string, f string,
+	err error) {
+	return a, b,
+		c,
+		d, e, f,
+		err // want "naked return in func `NamedReturnsOnMultipleLines` with 5 lines of code"
+}

--- a/testdata/src/x/nested.go.golden
+++ b/testdata/src/x/nested.go.golden
@@ -110,8 +110,5 @@ func NamedReturnsOnMultipleLines() (a, b int,
 	c int,
 	d, e string, f string,
 	err error) {
-	return a, b,
-		c,
-		d, e, f,
-		err // want "naked return in func `NamedReturnsOnMultipleLines` with 5 lines of code"
+	return a, b, c, d, e, f, err // want "naked return in func `NamedReturnsOnMultipleLines` with 5 lines of code"
 }


### PR DESCRIPTION
By default, go/printer.Fprintf() adds newlines with quite a bit of logic [1].
For naked return fixes, these are based on the `Pos()` of the identifiers that are copied from the named returns in the function declaration, which causes newlines to be added that match the layout in the function declaration when those named returns span multiple lines.

For example, the function
```go
func NamedReturnsOnMultipleLines() (a, b int,
	c int,
	d, e string, f string,
	err error) {
	return
}
```
generates the fix:
```go
	return a, b,
		c,
		d, e, f,
		err
```

It looks like by updating the `ident.NamePos` of all names to be the same as the first one this can be avoided, to give a fix on a single line:
```go
	return a, b, c, d, e, f, err
```

It looks like the internal logic checks:
```go
// go/printer/nodes.go

// Print a list of expressions. If the list spans multiple
// source lines, the original line breaks are respected between
// expressions. …
func (p *printer) exprList(…) { …
	if prev.IsValid() && prev.Line == line && line == endLine {
		// all list entries on a single line
		…
}
```
but this is not exposed / externally documented.


[1] an example of the logic:
```go
		// If the previous line and the current line had single-
		// line-expressions and the key sizes are small or the
		// ratio between the current key and the geometric mean
		// if the previous key sizes does not exceed a threshold,
		// align columns and do not use formfeed.
		if … if … else {
				const r = 2.5                               // threshold
				geomean := math.Exp(lnsum / float64(count)) // count > 0
				ratio := float64(size) / geomean
				useFF = r*ratio <= 1 || r <= ratio
```
